### PR TITLE
DO NOT MERGE: Update ProductPage to update quantity sha on quantity change

### DIFF
--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -302,7 +302,35 @@ JS;
 }
 
 class ProductPage_Controller extends Page_Controller {
+
+	private static $allowed_actions = array(
+		'quantityUpdate'
+	);
+
 	public function init(){
 		parent::init();
+
+		$absoluteURL = Director::AbsoluteURL(null);
+		$urlSeg = $this->Data()->URLSegment;
+		$code = $this->data()->Code;
+		// if page is restricted w/login, absolute url doesn't include current page, even if user is logged in
+		// check absolute url if the url segment of current page is present, if not add it and trailing slash
+		$currentURL = (strpos($absoluteURL,$urlSeg)) ? $absoluteURL : "{$absoluteURL}{$urlSeg}/";
+		Requirements::customScript(<<<JS
+var pageURL = "$currentURL";
+JS
+		);
+
+		Requirements::javascript(THIRDPARTY_DIR.'/jquery/jquery.min.js');
+		Requirements::javascript('foxystripe/js/quantity-update.js');
+
+	}
+
+	public function quantityUpdate($request = null){
+		$params = $this->getURLParams();
+		$value = $params['ID'];
+		$code = $this->data()->Code;
+		$newName = FoxyCart_Helper::fc_hash_value($code, 'quantity', $value);
+		return $newName;
 	}
 }

--- a/js/quantity-update.js
+++ b/js/quantity-update.js
@@ -1,0 +1,34 @@
+/**
+ * Created by nhorstmeier on 4/9/14.
+ */
+
+$(document).ready(function(){
+
+    $('.foxycart_qty input').change(function(){
+        var newValue = $('.foxycart_qty input').val();
+        getUpdatedSHA(newValue);
+    });
+
+});
+
+function getUpdatedSHA(newValue){
+
+    $.ajax({
+        type: 'GET',
+        //data: {'code': code},
+        url: pageURL+'quantityUpdate/'+newValue,
+        beforeSend: function(){
+            return ;
+        },
+        success: function(updatedValue){
+            $('.foxycart_qty input').attr('name', updatedValue);
+        },
+        error: function(er){
+            console.log(er.responseText);
+        },
+        complete: function(){
+
+        }
+    });
+
+}


### PR DESCRIPTION
This is a rough draft to update the quantity sha on change of that field to prevent failed cart validation. The issue is the ajax request won't get back soon enough if a user immediately clicks the Add To Cart button. I think disabling the add to cart button on keyUp or keyDown of that field, then re-enabling it on success of the sha update would be a possible solution to the delay.

Thoughts?
