### PR TITLE
implemented order history, fixes #5

### DIFF
--- a/Utilities/FoxyCartDataFeedCollector.php
+++ b/Utilities/FoxyCartDataFeedCollector.php
@@ -19,11 +19,13 @@ class FoxyCartDataFeedCollector extends Page_Controller {
 		// or it should be written to a directory that doesn't have public access (like with an .htaccess directive).
 		
 		if (isset($_POST["FoxyData"]) OR isset($_POST['FoxySubscriptionData'])) {
-			$FoxyData_encrypted = (isset($_POST["FoxyData"])) ? urldecode($_POST["FoxyData"]) : urldecode($_POST["FoxySubscriptionData"]);
-			$FoxyData_decrypted = rc4crypt::decrypt(FoxyCart::$storeKey,$FoxyData_encrypted);
+			$FoxyData_encrypted = (isset($_POST["FoxyData"])) ?
+                urldecode($_POST["FoxyData"]) :
+                urldecode($_POST["FoxySubscriptionData"]);
+			$FoxyData_decrypted = rc4crypt::decrypt(FoxyCart::getStoreKey(),$FoxyData_encrypted);
 			echo $FoxyData_decrypted;
 		} else {
-			user_error("No FoxyData or FoxySubscriptionData received.");
+			user_error("No FoxyData or FoxySubscription Data received.");
 		}
 	}
 	
@@ -33,8 +35,10 @@ class FoxyCartDataFeedCollector extends Page_Controller {
 		// or it should be written to a directory that doesn't have public access (like with an .htaccess directive).
 		
 		if (isset($_POST["FoxyData"]) OR isset($_POST['FoxySubscriptionData'])) {
-			$FoxyData_encrypted = (isset($_POST["FoxyData"])) ? urldecode($_POST["FoxyData"]) : urldecode($_POST["FoxySubscriptionData"]);
-			$FoxyData_decrypted = rc4crypt::decrypt(FoxyCart::$storeKey,$FoxyData_encrypted);
+			$FoxyData_encrypted = (isset($_POST["FoxyData"])) ?
+                urldecode($_POST["FoxyData"]) :
+                urldecode($_POST["FoxySubscriptionData"]);
+			$FoxyData_decrypted = rc4crypt::decrypt(FoxyCart::getStoreKey(),$FoxyData_encrypted);
 			self::handleDataFeed($FoxyData_encrypted, $FoxyData_decrypted);
 			return 'foxy';
 		} else {
@@ -43,7 +47,94 @@ class FoxyCartDataFeedCollector extends Page_Controller {
 	}
 	
 	public function handleDataFeed($encrypted, $decrypted){
-		//do what you want to with encrypted & decrypted data
+		//handle encrypted & decrypted data
+        $orders = new SimpleXMLElement($decrypted);
+
+        foreach ($orders->transactions->transaction as $order) {
+
+            if(isset($order->id)) {
+                ($transaction = Order::get()->filter('Order_ID', $order->id)->First()) ?
+                    $transaction :
+                    $transaction = Order::create();
+            }
+
+            // Record transaction data from FoxyCart Datafeed:
+            $transaction->Order_ID = (int) $order->id;
+            $transaction->Store_ID = (int) $order->store_id;
+            $transaction->StoreVersion = (string) $order->store_version;
+            $transaction->IsTest = (int) $order->is_test;
+            $transaction->IsHidden = (int) $order->is_hidden;
+            $transaction->DataIsFed = (int) $order->data_is_fed;
+            $transaction->TransactionDate = (string) $order->transaction_date;
+            $transaction->ProcessorResponse = (string) $order->processor_response;
+            $transaction->ShiptoShippingServiceDescription = (string) $order->shipto_shipping_service_description;
+            $transaction->ProductTotal = (float) $order->product_total;
+            $transaction->TaxTotal = (float) $order->tax_total;
+            $transaction->ShippingTotal = (float) $order->shipping_total;
+            $transaction->OrderTotal = (float) $order->order_total;
+            $transaction->PaymentGatewayType = (string) $order->payment_gateway_type;
+            $transaction->ReceiptURL = (string) $order->receipt_url;
+            $transaction->OrderStatus = (string) $order->status;
+
+            // Customer info
+            Config::inst()->update('Security', 'password_encryption_algorithm', 'none');
+            // if Customer is existing member, associate with current order
+            if(isset($order->customer_email)) {
+                ($customer = Member::get()->filter('Email', $order->customer_email)->First()) ?
+                    $customer :
+                    $customer = Member::create();
+            }
+            $customer->MinifraudScore = (string) $order->minifraud_score;
+            $customer->FirstName = (string) $order->customer_first_name;
+            $customer->Surname = (string) $order->customer_last_name;
+            $customer->Email = (string) $order->customer_email;
+            $customer->Password = (string) $order->customer_password;
+            $customer->Salt = (string) $order->customer_password_salt;
+            $customer->PasswordEncryption = 'none';
+            $customer->CustomerCompany = (string) $order->customer_company;
+            $customer->CustomerAddress1 = (string) $order->customer_address1;
+            $customer->CustomerAddress2 = (string) $order->customer_address2;
+            $customer->CustomerCity = (string) $order->customer_city;
+            $customer->CustomerState = (string) $order->customer_state;
+            $customer->CustomerPostalCode = (string) $order->customer_postal_code;
+            $customer->CustomerCountry = (string) $order->customer_country;
+            $customer->CustomerPhone = (string) $order->customer_phone;
+            $customer->CustomerIP = (int) $order->customer_ip;
+            $customer->ShippingFirstName = (string) $order->shipping_first_name;
+            $customer->ShippingLastName = (string) $order->shipping_last_name;
+            $customer->ShippingCompany = (string) $order->shipping_company;
+            $customer->ShippingAddress1 = (string) $order->shipping_address1;
+            $customer->ShippingAddress2 = (string) $order->shipping_address2;
+            $customer->ShippingCity = (string) $order->shipping_city;
+            $customer->ShippingState = (string) $order->shipping_state;
+            $customer->ShippingPostalCode = (string) $order->shipping_postal_code;
+            $customer->ShippingCountry = (string) $order->shipping_country;
+            $customer->ShippingPhone = (string) $order->shipping_phone;
+            $customer->write();
+
+            // Associate Member with Order
+            $transaction->MemberID = $customer->ID;
+
+            // Associate ProductPages with Order
+            foreach ($order->transaction_details->transaction_detail as $product) {
+                if(isset($product->product_code)) {
+                    ($OrderProduct = ProductPage::get()->filter('Code', (string) $product->product_code)->First()) ?
+                        $OrderProduct :
+                        false;
+                }
+                // If product exists add to Order->Products()
+                if (isset($OrderProduct)) $transaction->Products()->add(
+                    $OrderProduct,
+                    array('Quantity' => $product->product_quantity)
+                );
+            }
+
+            // record transaction as order
+            $transaction->write();
+
+        }
+
+        // allow this to be extended
 		$this->extend('handleDecryptedFeed',$encrypted, $decrypted);
 	}
 	

--- a/Utilities/rc4crypt.php
+++ b/Utilities/rc4crypt.php
@@ -35,7 +35,7 @@ class rc4crypt {
 	 * @access public
 	 * @return string
 	 */
-	function encrypt ($pwd, $data, $ispwdHex = 0)
+	static function encrypt ($pwd, $data, $ispwdHex = 0)
 	{
 		if ($ispwdHex)
 			$pwd = @pack('H*', $pwd); // valid input, please!
@@ -80,7 +80,7 @@ class rc4crypt {
 	 * @access public
 	 * @return string
 	 */
-	function decrypt ($pwd, $data, $ispwdHex = 0)
+	static function decrypt ($pwd, $data, $ispwdHex = 0)
 	{
 		return self::encrypt($pwd, $data, $ispwdHex);
 	}

--- a/_config.php
+++ b/_config.php
@@ -8,3 +8,5 @@
  * 
  *
  */
+
+Config::inst()->update('Security', 'password_encryption_algorithm', 'sha1_v2.4');

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,3 +4,6 @@ name: foxystripe
 SiteConfig:
   extensions:
     - FoxyCartSiteConfig
+Member:
+  extensions:
+    - CustomerExtension

--- a/code/admin/ProductAdmin.php
+++ b/code/admin/ProductAdmin.php
@@ -4,6 +4,7 @@ class ProductAdmin extends ModelAdmin {
 
 	public static $managed_models = array(
 		'ProductPage',
+        'Order',
 		'OptionGroup',
 		'OptionItem',
 		'ProductCategory'

--- a/code/extensions/CustomerExtension.php
+++ b/code/extensions/CustomerExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+class CustomerExtension extends DataExtension{
+
+    private static $db = array(
+        'Customer_ID' => 'Int',
+        'MinifraudScore' => 'Varchar',
+        'CustomerCompany' => 'Varchar',
+        'CustomerAddress1' => 'Varchar(200)',
+        'CustomerAddress2' => 'Varchar(200)',
+        'CustomerCity' => 'Varchar(100)',
+        'CustomerState' => 'Varchar(100)',
+        'CustomerPostalCode' => 'Varchar(10)',
+        'CustomerCountry' => 'Varchar(100)',
+        'CustomerPhone' => 'Varchar(20)',
+        'CustomerIP' => 'Varchar(20)',
+        'ShippingFirstName' => 'Varchar(100)',
+        'ShippingLastName' => 'Varchar(100)',
+        'ShippingCompany' => 'Varchar(100)',
+        'ShippingAddress1' => 'Varchar(200)',
+        'ShippingAddress2' => 'Varchar(200)',
+        'ShippingCity' => 'Varchar(100)',
+        'ShippingState' => 'Varchar(100)',
+        'ShippingPostalCode' => 'Varchar(10)',
+        'ShippingCountry' => 'Varchar(100)',
+        'ShippingPhone' => 'Varchar(20)'
+    );
+
+    public function onBeforeWrite() {
+        parent::onBeforeWrite();
+
+        $this->owner->PasswordEncryption = 'sha1_v2.4';
+    }
+
+}

--- a/code/objects/Order.php
+++ b/code/objects/Order.php
@@ -1,0 +1,74 @@
+<?php
+
+class Order extends DataObject {
+
+	private static $singular_name = 'Order';
+	private static $plural_name = 'Orders';
+	private static $description = 'Orders from FoxyCart Datafeed';
+
+	private static $db = array(
+        'Order_ID' => 'Int',
+        'Store_ID' => 'Int',
+        'StoreVersion' => 'Varchar',
+        'IsTest' => 'Boolean',
+        'IsHidden' => 'Boolean',
+        'DataIsFed' => 'Boolean',
+        'TransactionDate' => 'SS_Datetime',
+        'ProcessorResponse' => 'Varchar(200)',
+        'ShiptoShippingServiceDescription' => 'Varchar(200)',
+        'ProductTotal' => 'Currency',
+        'TaxTotal' => 'Currency',
+        'ShippingTotal' => 'Currency',
+        'OrderTotal' => 'Currency',
+        'PaymentGatewayType' => 'Varchar(100)',
+        'ReceiptURL' => 'Varchar(255)',
+        'OrderStatus' => 'Varchar(255)'
+    );
+
+	private static $has_one = array(
+        'Member' => 'Member'
+    );
+
+	private static $has_many = array();
+
+	private static $many_many = array(
+        'Products' => 'ProductPage'
+    );
+
+	private static $many_many_extraFields = array(
+        'Products' => array(
+            'Quantity' => 'Int'
+        )
+    );
+
+	private static $belongs_many_many = array();
+
+	private static $casting = array();
+	//private static $defaults = null;
+	//private static $default_sort = null;
+
+
+	private static $summary_fields = array();
+	private static $searchable_fields = array();
+	private static $field_labels = array();
+	private static $indexes = array();
+
+	public function getCMSFields(){
+		$fields = parent::getCMSFields();
+
+
+		$this->extend('updateCMSFields', $fields);
+		return $fields;
+	}
+
+	public function validate(){
+		$result = parent::validate();
+
+		/*if($this->Country == 'DE' && $this->Postcode && strlen($this->Postcode) != 5) {
+			$result->error('Need five digits for German postcodes');
+		}*/
+
+		return $result;
+	}
+
+}

--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -25,6 +25,10 @@ class ProductPage extends Page {
 		'ProductImages' => 'ProductImage',
 		'ProductOptions' => 'OptionItem'
 	);
+
+    private static $belongs_many_many = array(
+        'Orders' => 'Order'
+    );
 	
 	public function populateDefaults() {
 		parent::populateDefaults();


### PR DESCRIPTION
shipping first and last name in FoxyCartDatafeedCollector

Customer data from FC datafeed

fix for adding products to order

FoxyCartDatafeedCollector - associate ProductPage with Order

Member onBeforeWrite - set PasswordEncryption to sha1_2.4

member onAfterWrite - setPassword = false

fixed customer extension

Member onAfterWrite

set password_encryption_algorithm

hash work

custom passwordencryptor

add email to check variable values

hash work

trying to emulate FoxyCart password hash

set password encryption type

fixed typo

removed PasswordHash type

escaped customer data

customer sync from datafeed

initial work on transaction datafeed parsing
