### PR TITLE
ProductPage - updated colorbox.js requirement 

### DIFF
--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -324,7 +324,7 @@ class ProductPage_Controller extends Page_Controller {
 
 		if(SiteConfig::current_site_config()->CartPage==false){
 			Requirements::css('//cdn.foxycart.com/static/scripts/colorbox/1.3.19/style1_fc/colorbox.css?ver=1');
-			Requirements::javascript('//cdn.foxycart.com/dynamic/foxycart.colorbox.js?ver=2');
+			Requirements::javascript('//cdn.foxycart.com/' . FoxyCart::getFoxyCartStoreName() . '/foxycart.colorbox.js?ver=2');
 		}
 
 	}


### PR DESCRIPTION
to use FoxyCart::getStoreName() to populate path

Fixes #43
