### PR TITLE
Add to Cart Form - update price via JS fix

### DIFF
--- a/templates/Layout/ProductPage.ss
+++ b/templates/Layout/ProductPage.ss
@@ -23,7 +23,7 @@
 	        <div class="productTextContainer floatLeft">
 	            <h1>{$Title}</h1>
 	            <p>
-		            <strong>Price:</strong> $Price.Nice<br>
+		            <strong>Base Price:</strong> $Price.Nice<br>
 		            <strong>Weight:</strong> $Weight lbs<br>
 		            <strong>Code:</strong> $Code
 	            </p>


### PR DESCRIPTION
Fixes #92

Grabs base price from Product details HTML. Skips Quantity drop down when calculating new price based on product option modifiers.
