### PR TITLE
Update ProductPage to update many_many

### DIFF
--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -171,6 +171,25 @@ class ProductPage extends Page implements PermissionProvider {
 			$default = ProductCategory::get()->filter(array('Code' => 'DEFAULT'))->first();
 			$this->CategoryID = $default->ID;
 		}
+
+		//update many_many lists when multi-group is on
+		if(SiteConfig::current_site_config()->MultiGroup){
+			$holders = $this->ProductHolders();
+			$product = ProductPage::get()->byID($this->ID);
+			$origParent = $product->ParentID;
+			$currentParent = $this->ParentID;
+			if($origParent!=$currentParent){
+				if($holders->find('ID', $origParent)){
+					$holders->removeByID($origParent);
+				}
+				$holders->add($currentParent);
+			}
+		}
+	}
+
+	public function onAfterWrite(){
+		parent::onAfterWrite();
+
 	}
 	
 	public function onBeforeDelete() {


### PR DESCRIPTION
When a product page is moved to a new holder page with the multi-group enabled the page now handles adding/removing itself from the proper holders' many_many relations.

fixes #90
