### PR TITLE
BUGFIX PurchaseForm() can't be overwritten

### DIFF
--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -239,7 +239,7 @@ class ProductPage extends Page implements PermissionProvider {
 	
 	public function PurchaseForm(){
 		if($this->Available){
-			return (SiteConfig::current_site_config()->CartValidation) ? FoxyCart_Helper::fc_hash_html(self::ProductOptionsForm()) : self::ProductOptionsForm();
+			return (SiteConfig::current_site_config()->CartValidation) ? FoxyCart_Helper::fc_hash_html($this->ProductOptionsForm()) : $this->ProductOptionsForm();
 		}
 		return "<h3 class=\"unavailable-product\">Product currently unavailable</h3>";
 	}


### PR DESCRIPTION
fixes #143
