### PR TITLE
ProductPage - parent ProductHolder added onBeforeWrite

### DIFF
--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -171,24 +171,32 @@ class ProductPage extends Page implements PermissionProvider {
 			$default = ProductCategory::get()->filter(array('Code' => 'DEFAULT'))->first();
 			$this->CategoryID = $default->ID;
 		}
-
+		
 		//update many_many lists when multi-group is on
 		if(SiteConfig::current_site_config()->MultiGroup){
 			$holders = $this->ProductHolders();
 			$product = ProductPage::get()->byID($this->ID);
-			$origParent = $product->ParentID;
+			if (isset($product->ParentID)) {
+				$origParent = $product->ParentID;
+			} else {
+				$origParent = null;
+			}
 			$currentParent = $this->ParentID;
 			if($origParent!=$currentParent){
 				if($holders->find('ID', $origParent)){
 					$holders->removeByID($origParent);
 				}
-				$holders->add($currentParent);
+				
 			}
+			$holders->add($currentParent);
 		}
+
 	}
 
 	public function onAfterWrite(){
 		parent::onAfterWrite();
+		
+		
 
 	}
 	


### PR DESCRIPTION
Fixes #159 

Now will write the parent into Groups no matter what. If parent changes, will removed old parent.
