### PR TITLE
ENHANCEMENT update ProductCategory canDelete logic

### DIFF
--- a/code/objects/ProductCategory.php
+++ b/code/objects/ProductCategory.php
@@ -39,7 +39,7 @@ class ProductCategory extends DataObject {
         $this->extend('updateCMSFields', $fields);
         return $fields;
 	}
-	
+
 	public function requireDefaultRecords() {
 		parent::requireDefaultRecords();
 		$allCats = DataObject::get('ProductCategory');
@@ -60,7 +60,9 @@ class ProductCategory extends DataObject {
 	}
 
 	public function canDelete($member = null) {
-		return Permission::check('Product_CANCRUD');
+
+		//don't allow deletion of DEFAULT category
+		return ($this->Code == 'DEFAULT') ? false : Permission::check('Product_CANCRUD');
 	}
 
 	public function canCreate($member = null) {

--- a/tests/FoxyStripeTest.yml
+++ b/tests/FoxyStripeTest.yml
@@ -38,6 +38,9 @@ ProductCategory:
   default:
     Title: Default
     Code: DEFAULT
+  apparel:
+    Title: Apparel
+    Code: APPAREL
 # ------------------------------------------
 # Groups
 # ------------------------------------------

--- a/tests/ProductPageTest.php
+++ b/tests/ProductPageTest.php
@@ -10,7 +10,7 @@ class ProductPageTest extends FS_Test{
 
 	function testProductCreation(){
 
-		$this->loginAs('admin');
+		$this->logInWithPermission('Product_CANCRUD');
 		$default = $this->objFromFixture('ProductCategory', 'default');
 		$default->write();
 		$product1 = $this->objFromFixture('ProductPage', 'product1');
@@ -22,7 +22,7 @@ class ProductPageTest extends FS_Test{
 
 	function testProductDeletion(){
 
-		$this->loginAs('admin');
+		$this->logInWithPermission('Product_CANCRUD');
 		$product2 = $this->objFromFixture('ProductPage', 'product2');
 		$productID = $product2->ID;
 
@@ -41,6 +41,38 @@ class ProductPageTest extends FS_Test{
 		foreach($versions as $versionRow) $versionsPostDelete[] = $versionRow;
 
 		$this->assertTrue($versionsPostPublish == $versionsPostDelete);
+
+	}
+
+	function testProductCategoryCreation(){
+
+		$this->logInWithPermission('Product_CANCRUD');
+		$category = $this->objFromFixture('ProductCategory', 'default');
+		$category->write();
+
+		$this->assertNotNull(ProductCategory::get()->first());
+
+	}
+
+	function testProductCategoryDeletion(){
+
+		$this->logInWithPermission('Product_CANCRUD');
+		$category = $this->objFromFixture('ProductCategory', 'default');
+		$category->write();
+
+		$this->assertFalse($category->canDelete());
+
+		$category2 = $this->objFromFixture('ProductCategory', 'apparel');
+		$category2->write();
+
+		$this->assertTrue($category2->canDelete());
+
+		$this->logOut();
+
+		$this->logInWithPermission('ADMIN');
+
+		$this->assertFalse($category->canDelete());
+		$this->assertTrue($category2->canDelete());
 
 	}
 


### PR DESCRIPTION
```canDelete()``` should return false if it's for the default category as it is required for FoxyCart. If the code is something else then return the value of the ```Product_CANCRUD``` permission.