### PR TITLE
rename FoxyStripe_Controller, FoxyStripeSiteConfig

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,7 +3,7 @@ Name: foxystripe
 ---
 SiteConfig:
   extensions:
-    - FoxyCartSiteConfig
+    - FoxyStripeSiteConfig
 Member:
   extensions:
     - CustomerExtension

--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -4,4 +4,4 @@ After: framework/routes#coreroutes
 ---
 Director:
   rules:
-    'foxycart//$Action/$ID/$Name': 'FoxyCart_Controller'
+    'foxystripe//$Action/$ID/$Name': 'FoxyStripe_Controller'

--- a/code/controllers/FoxyStripe_Controller.php
+++ b/code/controllers/FoxyStripe_Controller.php
@@ -1,8 +1,8 @@
 <?php
 
-class FoxyCart_Controller extends Page_Controller {
+class FoxyStripe_Controller extends Page_Controller {
 	
-	const URLSegment = 'foxycart';
+	const URLSegment = 'foxystripe';
 
 	public function getURLSegment() {
 		return self::URLSegment;

--- a/code/extensions/FoxyStripeSiteConfig.php
+++ b/code/extensions/FoxyStripeSiteConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-class FoxyCartSiteConfig extends DataExtension{
+class FoxyStripeSiteConfig extends DataExtension{
 
 	private static $db = array(
 		'StoreName' => 'Varchar(255)',
@@ -72,11 +72,11 @@ class FoxyCartSiteConfig extends DataExtension{
 	}
 
     private static function getSSOLink() {
-        return Director::absoluteBaseURL()."foxycart/sso";
+        return Director::absoluteBaseURL()."foxystripe/sso";
     }
 
     private static function getDataFeedLink() {
-        return Director::absoluteBaseURL()."foxycart";
+        return Director::absoluteBaseURL()."foxystripe";
     }
 
 }


### PR DESCRIPTION
In FoxyCart Settings:

update datafeed URL and SSO URL from example.com/foxycart to example.com/foxystripe