### PR TITLE
Remove canView from ProductPage

### DIFF
--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -447,10 +447,6 @@ JS;
 	 * @param Member $member
 	 * @return boolean
 	 */
-	public function canView($member = false) {
-		return true;
-	}
-
 	public function canEdit($member = null) {
 		return Permission::check('Product_CANCRUD');
 	}


### PR DESCRIPTION
Fall back to definition in SiteTree

Fixes #161 