### PR TITLE
OptionGroup - ensure a default group exists

### DIFF
--- a/code/extensions/FoxyStripeSiteConfig.php
+++ b/code/extensions/FoxyStripeSiteConfig.php
@@ -30,7 +30,6 @@ class FoxyStripeSiteConfig extends DataExtension{
 			TextField::create('StoreName')
 				->setTitle('Store Sub Domain')
 				->setDescription('the sub domain for your FoxyCart store'),
-
 			// Advanced Settings
 			HeaderField::create('AdvanceHeader', 'Advanced Settings', 3),
 			LiteralField::create('AdvancedIntro',
@@ -46,9 +45,7 @@ class FoxyStripeSiteConfig extends DataExtension{
 				->setDescription('copy/paste from FoxyCart'),
 			ReadonlyField::create('SSOLink', 'Single Sign On URL', self::getSSOLink())
 				->setDescription('copy/paste to FoxyCart')
-
 		);
-
 		if(FoxyCart::store_key_warning()!==null){
 			array_unshift($fieldSet1, new LiteralField("StoreKeyHeaderWarning", "<p class=\"message error\">Store key must be entered in the <a href=\"/admin/settings/\">site settings</a></p>"));
 		}
@@ -58,16 +55,28 @@ class FoxyStripeSiteConfig extends DataExtension{
 
         $fields->addFieldsToTab('Root.FoxyStripe.Settings', $fieldSet1);
 
-        $fields->addFieldsToTab('Root.FoxyStripe.Products', array(
-            HeaderField::create('ProductGroupHeader', 'Product Groups', 3),
-            CheckboxField::create('MultiGroup')
-                ->setTitle('Multiple Product Groups')
-                ->setDescription('Allows products to be shown in multiple product holders'),
-            NumericField::create('ProductLimit')
-                ->setTitle('Products per page on Product Holder')
-        ));
+		$fields->addFieldsToTab('Root.FoxyStripe.Products', array(
+			HeaderField::create('ProductHeader', 'Products', 3),
+			CheckboxField::create('MultiGroup')
+				->setTitle('Multiple Groups')
+				->setDescription('Allows products to be shown in multiple Product Groups'),
+			HeaderField::create('ProductGroupHeader', 'Product Groups', 3),
+			NumericField::create('ProductLimit')
+				->setTitle('Products per Page')
+				->setDescription('Number of Products to show per page on a Product Group')
+		));
 
-        
+		$fields->addFieldsToTab('Root.FoxyStripe.Categories', array(
+			HeaderField::create('CategoryHead', 'FoxyStripe Categories', 3),
+			LiteralField::create('CategoryDescrip', '<p>FoxyCart Categories offer a way to give products additional behaviors that cannot be accomplished by product options alone, including category specific coupon codes, shipping and handling fees, and email receipts. <a href="https://wiki.foxycart.com/v/2.0/categories" target="_blank">Learn More</a></p><p>Categories you\'ve created in FoxyStripe must also be created in your <a href="https://admin.foxycart.com/admin.php?ThisAction=ManageProductCategories" target="_blank">FoxyCart Categories</a> admin panel.</p>'),
+			GridField::create('ProductCategory', 'FoxyCart Categories', ProductCategory::get(), GridFieldConfig_RecordEditor::create())
+		));
+
+		$fields->addFieldsToTab('Root.FoxyStripe.Groups', array(
+			HeaderField::create('OptionGroupsHead', 'Product Option Groups', 3),
+			LiteralField::create('OptionGroupsDescrip', '<p>Product Option Groups allow you to name a set of product options.</p>'),
+			GridField::create('OptionGroup', 'Product Option Groups', OptionGroup::get(), GridFieldConfig_RecordEditor::create())
+		));
 
 	}
 

--- a/code/objects/OptionGroup.php
+++ b/code/objects/OptionGroup.php
@@ -26,6 +26,12 @@ class OptionGroup extends DataObject{
 
 	public function requireDefaultRecords() {
 		parent::requireDefaultRecords();
+		// create a catch-all group
+		if(!OptionGroup::get()->filter(array('Title' => 'Options'))->first()) {
+			$do = new OptionGroup();
+			$do->Title = "Options";
+			$do->write();
+		}
 		if(!OptionGroup::get()->filter(array('Title' => 'Size'))->first()) {
             $do = new OptionGroup();
             $do->Title = "Size";
@@ -50,7 +56,7 @@ class OptionGroup extends DataObject{
 		$items = OptionItem::get()->filter(array('ProductOptionGroupID' => $this->ID));
 
 		if(isset($items)){
-			$noneGroup = OptionGroup::get()->filter(array('Title' => 'None'))->first();
+			$noneGroup = OptionGroup::get()->filter(array('Title' => 'Options'))->first();
 			foreach($items as $item){
 				$item->ProductOptionGroupID = $noneGroup->ID;
 				$item->write();
@@ -63,11 +69,19 @@ class OptionGroup extends DataObject{
 	}
 
 	public function canEdit($member = null) {
-		return Permission::check('Product_CANCRUD');
+		switch($this->Title){
+			case 'Options':
+				return false;
+				break;
+			default:
+				return Permission::check('Product_CANCRUD');
+				break;
+		}
+
 	}
 
 	public function canDelete($member = null) {
-		return Permission::check('Product_CANCRUD');
+		return $this->canEdit();
 	}
 
 	public function canCreate($member = null) {


### PR DESCRIPTION
Fixes #156

Create a default OptionGroup 'options', which cannot be edited or deleted. If an OptionGroup is deleted, all OptionItems that belonged to the group will be reassigned to 'options'.

Fixed missing 'Groups' and 'Categories' tabs in FoxyStripe > Settings