### PR TITLE
ProductPage - set default_parent, can_be_root - bug fix

### DIFF
--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -8,6 +8,8 @@
 class ProductPage extends Page implements PermissionProvider {
 
 	private static $allowed_children = 'none';
+    private static $default_parent = 'ProductHolder';
+    private static $can_be_root = false;
 
 	private static $db = array(
 		'Price' => 'Currency',

--- a/tests/ProductDiscountTierTest.php
+++ b/tests/ProductDiscountTierTest.php
@@ -7,7 +7,12 @@ class ProductDiscountTierTest extends FS_Test{
 	function setUp(){
 		parent::setUp();
 
+		$productHolder = ProductHolder::create();
+		$productHolder->Title = 'Product Holder';
+		$productHolder->write();
+
 		$product = $this->objFromFixture('ProductPage', 'product1');
+		$product->ParentID = $productHolder->ID;
 		$product->write();
 	}
 

--- a/tests/ProductPageTest.php
+++ b/tests/ProductPageTest.php
@@ -10,6 +10,10 @@ class ProductPageTest extends FS_Test{
 		$groupForItem = OptionGroup::create();
 		$groupForItem->Title = 'Sample-Group';
 		$groupForItem->write();
+
+		$productHolder = ProductHolder::create();
+		$productHolder->Title = 'Product Holder';
+		$productHolder->write();
 	}
 
 	function testProductCreation(){
@@ -18,6 +22,7 @@ class ProductPageTest extends FS_Test{
 		$default = $this->objFromFixture('ProductCategory', 'default');
 		$default->write();
 		$product1 = $this->objFromFixture('ProductPage', 'product1');
+		$product1->ParentID = ProductHolder::get()->first()->ID;
 
 		$product1->doPublish();
 		$this->assertTrue($product1->isPublished());
@@ -28,6 +33,7 @@ class ProductPageTest extends FS_Test{
 
 		$this->logInWithPermission('Product_CANCRUD');
 		$product2 = $this->objFromFixture('ProductPage', 'product2');
+		$product2->ParentID = ProductHolder::get()->first()->ID;
 		$productID = $product2->ID;
 
 		$product2->doPublish();
@@ -53,6 +59,7 @@ class ProductPageTest extends FS_Test{
 		$this->logInWithPermission('ADMIN');
 		$product = $this->objFromFixture('ProductPage', 'product1');
 		$product->Title = " Test with leading space";
+		$product->ParentID = ProductHolder::get()->first()->ID;
 		$product->doPublish();
 
 		$this->assertTrue($product->Title == 'Test with leading space');
@@ -64,6 +71,7 @@ class ProductPageTest extends FS_Test{
 		$this->logInWithPermission('ADMIN');
 		$product = $this->objFromFixture('ProductPage', 'product1');
 		$product->Title = "Test with trailing space ";
+		$product->ParentID = ProductHolder::get()->first()->ID;
 		$product->doPublish();
 
 		$this->assertTrue($product->Title == 'Test with trailing space');


### PR DESCRIPTION
fixes #232

since ProductPage is hidden from navigation, only allows ProductPage to be a subpage of ProductHolder