### PR TITLE
CRITICAL BUGFIX Status no longer a column in SiteTree

### DIFF
--- a/code/pages/ProductPage.php
+++ b/code/pages/ProductPage.php
@@ -266,20 +266,22 @@ class ProductPage extends Page implements PermissionProvider {
 	}
 
 	public function onBeforeDelete() {
-		if($this->Status != "Published") {
+		if(!$this->isPublished()) {
+
+			$delete = function($object){
+				$object->delete();
+			};
+
 			if($this->ProductOptions()) {
 				$options = $this->getComponents('ProductOptions');
-				foreach($options as $option) {
-					$option->delete();
-				}
+				$options->each($delete);
 			}
 			if($this->ProductImages()) {
 				//delete product image dataobjects, not the images themselves.
 				$images = $this->getComponents('ProductImages');
-				foreach($images as $image) {
-					$image->delete();
-				}
+				$images->each($delete);
 			}
+
 		}
 		parent::onBeforeDelete();
 	}

--- a/tests/FoxyStripeTest.yml
+++ b/tests/FoxyStripeTest.yml
@@ -1,3 +1,14 @@
+ProductCategory:
+  default:
+    Title: Default
+    Code: DEFAULT
+  apparel:
+    Title: Apparel
+    Code: APPAREL
+ProductHolder:
+  holder:
+    Title: Product Holder Test
+    URLSegment: product-holder-test
 ProductPage:
   product1:
     Title: Product 1
@@ -9,6 +20,7 @@ ProductPage:
     Featured: 0
     Available: 1
     CategoryID: 1
+    Parent: =>ProductHolder.holder
   product2:
     Title: Product 2
     URLSegment: product-2
@@ -19,7 +31,8 @@ ProductPage:
     Featured: 1
     Available: 1
     CategoryID: 1
-  product2:
+    Parent: =>ProductHolder.holder
+  product3:
     Title: Product 3
     URLSegment: product-3
     Price: 176
@@ -29,18 +42,7 @@ ProductPage:
     Featured: 1
     Available: 0
     CategoryID: 1
-OptionGroup:
-  og1:
-    Title: Size
-  og2:
-    Title: Color
-ProductCategory:
-  default:
-    Title: Default
-    Code: DEFAULT
-  apparel:
-    Title: Apparel
-    Code: APPAREL
+    Parent: =>ProductHolder.holder
 OptionGroup:
   size:
     Title: Size
@@ -56,6 +58,8 @@ OptionItem:
     CodeModifieraction: Add
     PriceModifierAction: Subtract
     Available: true
+    ProductOptionGroup: =>OptionGroup.size
+    Product: =>ProductPage.product1
   small:
     Title: Small
     WeightModifier: 2
@@ -65,6 +69,8 @@ OptionItem:
     CodeModifieraction: Subtract
     PriceModifierAction: Add
     Available: false
+    ProductOptionGroup: =>OptionGroup.size
+    Product: =>ProductPage.product1
 ProductDiscountTier:
   fiveforten:
     Quantity: 5


### PR DESCRIPTION
fixes #248

The previous check `$this->Status != "Published"` is no longer valid as `Status` is no longer a column in `SiteTree`. The check now accesses the `isPublished()` method wich returns a boolean.

The deleting of `ProductOptions` and `ProductImages` in `onBeforeDelete()` have been also optimized by utilizing a shared closure rather than separate `foreach` loops