### PR TITLE
Order Parsing and History reworking

### DIFF
--- a/code/controllers/FoxyStripe_Controller.php
+++ b/code/controllers/FoxyStripe_Controller.php
@@ -14,12 +14,16 @@ class FoxyStripe_Controller extends Page_Controller {
 	);
 	
 	public function index() {
+
 	    // handle POST from FoxyCart API transaction
 		if ((isset($_POST["FoxyData"]) OR isset($_POST['FoxySubscriptionData']))) {
+
 			$FoxyData_encrypted = (isset($_POST["FoxyData"])) ?
                 urldecode($_POST["FoxyData"]) :
                 urldecode($_POST["FoxySubscriptionData"]);
 			$FoxyData_decrypted = rc4crypt::decrypt(FoxyCart::getStoreKey(),$FoxyData_encrypted);
+
+            // parse the response and save the order
 			self::handleDataFeed($FoxyData_encrypted, $FoxyData_decrypted);
 			
 			// extend to allow for additional integrations with Datafeed
@@ -35,186 +39,28 @@ class FoxyStripe_Controller extends Page_Controller {
 	}
 
     public function handleDataFeed($encrypted, $decrypted){
-        //handle encrypted & decrypted data
+
         $orders = new SimpleXMLElement($decrypted);
 
         // loop over each transaction to find FoxyCart Order ID
-        foreach ($orders->transactions->transaction as $order) {
+        foreach ($orders->transactions->transaction as $transaction) {
 
-            if (isset($order->id)) {
-                ($transaction = Order::get()->filter('Order_ID', $order->id)->First()) ?
-                    $transaction :
-                    $transaction = Order::create();
-            }
+            // if FoxyCart order id, then parse order
+            if (isset($transaction->id)) {
 
-            // save base order info
-            $transaction->Order_ID = (int) $order->id;
-            $transaction->Response = $decrypted;
+                ($order = Order::get()->filter('Order_ID', (int) $transaction->id)->First()) ?
+                    $order = Order::get()->filter('Order_ID', (int) $transaction->id)->First() :
+                    $order = Order::create();
 
-            // record transaction as order
-            $transaction->write();
-
-            // parse order
-            $this->parseOrder($order->id);
-
-        }
-    }
-
-    public function parseOrder($Order_ID) {
-
-        $transaction = Order::get()->filter(array('Order_ID' => $Order_ID))->First();
-
-        if ($transaction) {
-            // grab response, parse as XML
-            $orders = new SimpleXMLElement($transaction->Response);
-
-            $this->parseOrderInfo($orders, $transaction);
-            $this->parseOrderCustomer($orders, $transaction);
-            // record transaction so user info can be accessed from parseOrderDetails()
-            $transaction->write();
-            $this->parseOrderDetails($orders, $transaction);
-
-            // record transaction as order
-            $transaction->write();
-        }
-    }
-
-    public function parseOrderInfo($orders, $transaction) {
-
-        foreach ($orders->transactions->transaction as $order) {
-
-            // Record transaction data from FoxyCart Datafeed:
-            $transaction->Store_ID = (int)$order->store_id;
-            $transaction->TransactionDate = (string)$order->transaction_date;
-            $transaction->ProductTotal = (float)$order->product_total;
-            $transaction->TaxTotal = (float)$order->tax_total;
-            $transaction->ShippingTotal = (float)$order->shipping_total;
-            $transaction->OrderTotal = (float)$order->order_total;
-            $transaction->ReceiptURL = (string)$order->receipt_url;
-            $transaction->OrderStatus = (string)$order->status;
-        }
-    }
-
-    public function parseOrderCustomer($orders, $transaction) {
-
-        foreach ($orders->transactions->transaction as $order) {
-
-            // if not a guest transaction in FoxyCart
-            if (isset($order->customer_email) && $order->is_anonymous == 0) {
-
-                // if Customer is existing member, associate with current order
-                if(Member::get()->filter('Email', $order->customer_email)->First()) {
-
-                    $customer = Member::get()->filter('Email', $order->customer_email)->First();
-
-                    /* todo: make sure local password is updated if changed on FoxyCart
-                    $customer->Password = (string)$order->customer_password;
-                    $customer->write();
-
-                    $customer->Password = (string)$order->customer_password;
-                    $customer->Salt = (string)$order->customer_password_salt;
-                    $customer->write();
-                    */
-
-                } else {
-
-                    // set PasswordEncryption to 'none' so imported, encrypted password is not encrypted again
-                    Config::inst()->update('Security', 'password_encryption_algorithm', 'none');
-
-                    // create new Member, set password info from FoxyCart
-                    $customer = Member::create();
-                    $customer->Customer_ID = (int)$order->customer_id;
-                    $customer->FirstName = (string)$order->customer_first_name;
-                    $customer->Surname = (string)$order->customer_last_name;
-                    $customer->Email = (string)$order->customer_email;
-                    $customer->Password = (string)$order->customer_password;
-                    $customer->PasswordEncryption = 'none';
-
-                    // record member record
-                    $customer->write();
-
-                    $customer->Password = (string)$order->customer_password;
-                    $customer->Salt = (string)$order->customer_password_salt;
-
-                    $customer->write();
-
-                }
-
-                // set Order MemberID
-                $transaction->MemberID = $customer->ID;
+                // save base order info
+                $order->Order_ID = (int) $transaction->id;
+                $order->Response = urlencode($encrypted);
+                $order->write();
 
             }
+
         }
     }
-
-    public function parseOrderDetails($orders, $transaction) {
-
-        // remove previous OrderDetails so we don't end up with duplicates
-        foreach ($transaction->Details() as $detail) {
-            $detail->delete();
-        }
-
-        foreach ($orders->transactions->transaction as $order) {
-
-            // Associate ProductPages, Options, Quanity with Order
-            foreach ($order->transaction_details->transaction_detail as $product) {
-
-                $OrderDetail = OrderDetail::create();
-
-                // set Quantity
-                $OrderDetail->Quantity = (int)$product->product_quantity;
-
-                // set calculated price (after option modifiers)
-                $OrderDetail->Price = (float)$product->product_price;
-
-                // Find product via product_id custom variable
-                foreach ($product->transaction_detail_options->transaction_detail_option as $productID) {
-                    if ($productID->product_option_name == 'product_id') {
-
-                        $OrderProduct = ProductPage::get()
-                            ->filter('ID', (int)$productID->product_option_value)
-                            ->First();
-
-                        // if product could be found, then set Option Items
-                        if ($OrderProduct) {
-
-                            // set ProductID
-                            $OrderDetail->ProductID = $OrderProduct->ID;
-
-                            // loop through all Product Options
-                            foreach ($product->transaction_detail_options->transaction_detail_option as $option) {
-
-                                $OptionItem = OptionItem::get()->filter(array(
-                                    'ProductID' => (string)$OrderProduct->ID,
-                                    'Title' => (string)$option->product_option_value
-                                ))->First();
-
-                                if ($OptionItem) {
-                                    $OrderDetail->Options()->add($OptionItem);
-
-                                    // modify product price
-                                    if ($priceMod = $option->price_mod) {
-                                        $OrderDetail->Price += $priceMod;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // associate with this order
-                    $OrderDetail->OrderID = $transaction->ID;
-
-                    // extend OrderDetail parsing, allowing for recording custom fields from FoxyCart
-                    $this->extend('handleOrderItem', $decrypted, $product, $OrderDetail);
-
-                    // write
-                    $OrderDetail->write();
-
-                }
-            }
-        }
-    }
-
 
 
 	// Single Sign on integration with FoxyCart

--- a/code/objects/Order.php
+++ b/code/objects/Order.php
@@ -33,8 +33,8 @@ class Order extends DataObject implements PermissionProvider
         'TransactionDate.NiceUS',
         'Member.Name',
         'ProductTotal.Nice',
-        'TaxTotal.Nice',
         'ShippingTotal.Nice',
+        'TaxTotal.Nice',
         'OrderTotal.Nice',
         'ReceiptLink'
     );
@@ -90,16 +90,165 @@ class Order extends DataObject implements PermissionProvider
         return $obj;
     }
 
-    public function canView($member = false)
-    {
-        return Permission::check('Product_ORDERS');
+    public function getDecryptedResponse() {
+        $decrypted = urldecode($this->Response);
+        return rc4crypt::decrypt(FoxyCart::getStoreKey(), $decrypted);
     }
 
-    public function canEdit($member = null)
-    {
-        //return Permission::check('Product_ORDERS');
-        return false;
+    public function onBeforeWrite() {
+
+        $this->parseOrder();
+        parent::onBeforeWrite();
     }
+
+    public function parseOrder() {
+
+        if ($this->getDecryptedResponse()) {
+
+            $response = new SimpleXMLElement($this->getDecryptedResponse());
+
+            $this->parseOrderInfo($response);
+            $this->parseOrderCustomer($response);
+            $this->parseOrderDetails($response);
+
+            return true;
+
+        } else {
+
+            return false;
+
+        }
+    }
+
+    public function parseOrderInfo($response) {
+
+        foreach ($response->transactions->transaction as $transaction) {
+
+            // Record transaction data from FoxyCart Datafeed:
+            $this->Store_ID = (int) $transaction->store_id;
+            $this->TransactionDate = (string) $transaction->transaction_date;
+            $this->ProductTotal = (float) $transaction->product_total;
+            $this->TaxTotal = (float) $transaction->tax_total;
+            $this->ShippingTotal = (float) $transaction->shipping_total;
+            $this->OrderTotal = (float) $transaction->order_total;
+            $this->ReceiptURL = (string) $transaction->receipt_url;
+            $this->OrderStatus = (string) $transaction->status;
+
+            $this->extend('handleOrderInfo', $order, $response);
+        }
+    }
+
+    public function parseOrderCustomer($response) {
+
+        foreach ($response->transactions->transaction as $transaction) {
+
+            // if not a guest transaction in FoxyCart
+            if (isset($transaction->customer_email) && $transaction->is_anonymous == 0) {
+
+                // if Customer is existing member, associate with current order
+                if(Member::get()->filter('Email', $transaction->customer_email)->First()) {
+
+                    $customer = Member::get()->filter('Email', $transaction->customer_email)->First();
+
+                    // if new customer, create account with data from FoxyCart
+                } else {
+
+                    // set PasswordEncryption to 'none' so imported, encrypted password is not encrypted again
+                    Config::inst()->update('Security', 'password_encryption_algorithm', 'none');
+
+                    // create new Member, set password info from FoxyCart
+                    $customer = Member::create();
+                    $customer->Customer_ID = (int) $transaction->customer_id;
+                    $customer->FirstName = (string) $transaction->customer_first_name;
+                    $customer->Surname = (string) $transaction->customer_last_name;
+                    $customer->Email = (string) $transaction->customer_email;
+                    $customer->Password = (string) $transaction->customer_password;
+                    $customer->Salt = (string) $transaction->customer_password_salt;
+                    $customer->PasswordEncryption = 'none';
+
+                    // record member record
+                    $customer->write();
+                }
+
+                // set Order MemberID
+                $this->MemberID = $customer->ID;
+
+                $this->extend('handleOrderCustomer', $order, $response, $customer);
+
+            }
+        }
+    }
+
+    public function parseOrderDetails($response) {
+
+        // remove previous OrderDetails and OrderOptions so we don't end up with duplicates
+        foreach ($this->Details() as $detail) {
+            foreach ($detail->OrderOptions() as $orderOption) {
+                $orderOption->delete();
+            }
+            $detail->delete();
+        }
+
+        foreach ($response->transactions->transaction as $transaction) {
+
+            // Associate ProductPages, Options, Quantity with Order
+            foreach ($transaction->transaction_details->transaction_detail as $detail) {
+
+                $OrderDetail = OrderDetail::create();
+
+                $OrderDetail->Quantity = (int) $detail->product_quantity;
+                $OrderDetail->ProductName = (string) $detail->product_name;
+                $OrderDetail->ProductCode = (string) $detail->product_code;
+                $OrderDetail->ProductImage = (string) $detail->image;
+                $OrderDetail->ProductCategory = (string) $detail->category_code;
+                $priceModifier = 0;
+
+                // parse OrderOptions
+                foreach ($detail->transaction_detail_options->transaction_detail_option as $option) {
+
+                    // Find product via product_id custom variable
+                    if ($option->product_option_name == 'product_id') {
+
+                        // if product is found, set relation to OrderDetail
+                        $OrderProduct = ProductPage::get()->byID((int) $option->product_option_value);
+                        if ($OrderProduct) $OrderDetail->ProductID = $OrderProduct->ID;
+
+                    } else {
+
+                        $OrderOption = OrderOption::create();
+                        $OrderOption->Name = (string) $option->product_option_name;
+                        $OrderOption->Value = (string) $option->product_option_value;
+                        $OrderOption->write();
+                        $OrderDetail->OrderOptions()->add($OrderOption);
+
+                        $priceModifier += $option->price_mod;
+                    }
+
+                }
+
+                $OrderDetail->Price = (float) $detail->product_price + (float) $priceModifier;
+
+                // extend OrderDetail parsing, allowing for recording custom fields from FoxyCart
+                $this->extend('handleOrderItem', $order, $response, $OrderDetail);
+
+                // write
+                $OrderDetail->write();
+
+                // associate with this order
+                $this->Details()->add($OrderDetail);
+            }
+        }
+    }
+
+
+	public function canView($member = false) {
+		return Permission::check('Product_ORDERS');
+	}
+
+	public function canEdit($member = null) {
+        return false;
+        //return Permission::check('Product_ORDERS');
+	}
 
     public function canDelete($member = null)
     {

--- a/code/objects/OrderDetail.php
+++ b/code/objects/OrderDetail.php
@@ -22,7 +22,11 @@ class OrderDetail extends DataObject
      */
     private static $db = array(
         'Quantity' => 'Int',
-        'Price' => 'Currency'
+        'Price' => 'Currency',
+        'ProductName' => 'Varchar(255)',
+        'ProductCode' => 'Varchar(100)',
+        'ProductImage' => 'Text',
+        'ProductCategory' => 'Varchar(100)'
     );
 
     /**
@@ -33,11 +37,8 @@ class OrderDetail extends DataObject
         'Order' => 'Order'
     );
 
-    /**
-     * @var array
-     */
-    private static $many_many = array(
-        'Options' => 'OptionItem'
+    private static $has_many = array(
+        'OrderOptions' => 'OrderOption'
     );
 
     /**
@@ -99,5 +100,15 @@ class OrderDetail extends DataObject
     public function canCreate($member = null)
     {
         return false;
-    }
+        //return Permission::check('Product_ORDERS');
+	}
+
+	public function canDelete($member = null) {
+		return Permission::check('Product_ORDERS');
+	}
+
+	public function canCreate($member = null) {
+		return false;
+	}
+
 }

--- a/code/objects/OrderOption.php
+++ b/code/objects/OrderOption.php
@@ -1,0 +1,19 @@
+<?php
+
+class OrderOption extends DataObject {
+
+    private static $db = array(
+        'Name' => 'Varchar(200)',
+        'Value' => 'Varchar(200)'
+    );
+
+    private static $has_one = array(
+        'OrderDetail' => 'OrderDetail'
+    );
+
+    private static $summary_fields = array(
+        'Name',
+        'Value'
+    );
+
+}

--- a/tasks/EncryptResponsesTask.php
+++ b/tasks/EncryptResponsesTask.php
@@ -1,0 +1,33 @@
+<?php
+
+class EncryptResponsesTask extends BuildTask {
+
+    protected $title = 'FoxyStripe Orders: Encrypt Responses Task';
+    protected $description = 'Encrypt any unencrypted FoxyCart datafeed responses. Migrate from old versions of FoxyStripe that didn\'t save responses encrypted';
+
+
+    public function run($request) {
+
+        $ct = 0;
+        $needle = '<?xml version="1.0" encoding="UTF-8"';
+        $needle2 = "<?xml version='1.0' encoding='UTF-8'";
+        $length = strlen($needle);
+
+        foreach (Order::get() as $order) {
+
+            if (substr($order->Response, 0, $length) === $needle || substr($order->Response, 0, $length) === $needle2) {
+
+                $encrypted = rc4crypt::encrypt(FoxyCart::getStoreKey(), $order->Response);
+                $encrypted = urlencode($encrypted);
+
+                $order->Response = $encrypted;
+                $order->write();
+                $ct++;
+            }
+
+        }
+        echo $ct . ' order responses encrypted';
+
+    }
+
+}

--- a/tasks/ParseOrdersTask.php
+++ b/tasks/ParseOrdersTask.php
@@ -1,0 +1,21 @@
+<?php
+class ParseOrdersTask extends BuildTask
+{
+    protected $title = 'FoxyStripe Orders: Parse all Orders';
+    protected $description = 'Generate new order information from the FoxyCart Datafeed XML';
+
+
+    public function run($request) {
+
+        $ct = 0;
+        foreach (Order::get() as $order) {
+            if ($order->parseOrder()) {
+                $order->write();
+                $ct++;
+            }
+        }
+        echo $ct . ' orders updated';
+
+    }
+
+}

--- a/templates/Layout/OrderHistoryPage.ss
+++ b/templates/Layout/OrderHistoryPage.ss
@@ -15,36 +15,54 @@
         <% if $Orders %>
             <% loop $Orders %>
                 <div class="historySummary line">
-                    <div class="sidebar size1of4 unit">
-                        <h3>$TransactionDate.NiceUS</h3>
+                    <div class="size1of4 unit">
+                        <h3>Order #{$Order_ID}</h3>
                         <p>
-	                        <a href="$ReceiptURL" target="_blank">View Invoice</a><br>
-	                        Order #{$Order_ID}<br>
-	                        Total $OrderTotal.Nice
-	                    </p>
+                            $TransactionDate.NiceUS | <a href="$ReceiptURL" target="_blank">View Invoice</a>
+                        </p>
+
+                        <table width="100%">
+                            <tr>
+                                <td><b>Sub Total</b></td>
+                                <td align="right" width="50%">$ProductTotal.Nice</td>
+                            </tr>
+                            <tr>
+                                <td><b>Shipping</b></td>
+                                <td align="right" width="50%">$ShippingTotal.Nice</td>
+                            </tr>
+                            <tr>
+                                <td><b>Tax</b></td>
+                                <td align="right" width="50%">$TaxTotal.Nice</td>
+                            </tr>
+                            <tr>
+                                <td><b>Total</b></td>
+                                <td align="right" width="50%"><b>$OrderTotal.Nice</b></td>
+                            </tr>
+                        </table>
                     </div>
                     <div class="size3of4 lastUnit">
+                        <h3>Your Items</h3>
 	                    <% loop $Details %>
-                            <div class="unit size2of5 productSummaryImage">
-                                <% with Product %>
-                                	<a href="{$Link}" title="{$Title}" class="anchor-fix product-image">
-										$PreviewImage.PaddedImage(250, 250)
-                                	</a>
-                                <% end_with %>
+                            <div class="unit size1of5 productSummaryImage">
+                                <% if $Product %>
+                                	<a href="{$Product.Link}" title="{$Product.Title}" class="anchor-fix product-image">
+                                <% end_if %>
+                                <img src="$ProductImage">
+                                <% if $Product %></a><% end_if %>
                             </div>
-                            <div class="unit size3of5 productSummaryText">
-                                <% with Product %>
-                                    <h3><a href="{$Link}" title="{$Title.XML}">$Title</a></h3>
-                                <% end_with %>
+                            <div class="unit size4of5 productSummaryText">
+                                <h3>
+                                    <% if $Product %><a href="{$Product.Link}" title="{$ProductName.XML}"><% end_if %>
+                                        $ProductName
+                                    <% if $Product %></a><% end_if %>
+                                </h3>
                                 <p>
-                                    <b>Quantity</b>: $Quantity
-                                    <% if $Options %>
-                                        <br>
-                                        <% loop $Options %>
-                                            <b>{$ProductOptionGroup.Title}</b>: $Title<% if Last %><% else %><br><% end_if %>
+                                    <% if $OrderOptions %>
+                                        <% loop $OrderOptions %>
+                                            <b>$Name</b>: $Value<br>
                                         <% end_loop %>
                                     <% end_if %>
-                                    <br>
+                                    <b>Quantity</b>: $Quantity<br>
                                     <b>Price:</b> $Price.Nice
                                 </p>
                             </div>


### PR DESCRIPTION
Replaced relationships between OrderDetail and OptionItems with new OrderOption object.

Overhaul of the various parsing functions, simplifying and clarifying. Moved to Order.

Order History page displays Product info from Datafeed, links to Product page if it exists/matches.

Order->Response is now saved encrypted.

Added two new BuildTasks:

FoxyStripe: ParseOrders - loops through all orders in the database that have a value for Response, and re-parses the Order data.

FoxyStripe: EncryptReponses - loops through all Orders and encrypts any Response fields that are unencrypted XML. For legacy migrations.
