### PR TITLE
BUGFIX ProductPage::getIsAvailable() returns false if no options preset

### DIFF
--- a/src/Page/ProductPage.php
+++ b/src/Page/ProductPage.php
@@ -395,6 +395,7 @@ class ProductPage extends \Page implements PermissionProvider
         if ($this->getSortedImages()->count() > 0) {
             return $this->getSortedImages()->first();
         }
+
         return false;
     }
 
@@ -522,6 +523,10 @@ class ProductPage extends \Page implements PermissionProvider
     {
         if (!$this->Available) {
             return false;
+        }
+
+        if (!$this->ProductOptions()->exists()) {
+            return true;
         }
 
         foreach ($this->ProductOptions() as $option) {


### PR DESCRIPTION
This is problematic for available products that don’t have options. If the product is marked as available and there are no options, it will return true for availability.