### PR TITLE
REFACTOR don’t explicitly set new encryptor

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -28,10 +28,3 @@ SilverStripe\Core\Injector\Injector:
     properties:
       format: '%Region/%Name'
 
-SilverStripe\Security\Security:
-  password_encryption_algorithm: 'bcrypt'
-
-'SilverStripe\Security\PasswordEncryptor':
-  encryptors:
-    bcrypt:
-      'Dynamic\FoxyStripe\Security\PasswordEncryptor_BCrypt':

--- a/src/Security/PasswordEncryptor_BCrypt.php
+++ b/src/Security/PasswordEncryptor_BCrypt.php
@@ -3,6 +3,7 @@
 namespace Dynamic\FoxyStripe\Security;
 
 use SilverStripe\Security\PasswordEncryptor;
+use SilverStripe\Security\PasswordEncryptor_EncryptionFailed;
 
 /**
  * Class PasswordEncryptor_BCrypt
@@ -46,8 +47,10 @@ class PasswordEncryptor_BCrypt extends PasswordEncryptor
 
     /**
      * @param String $password
+     * @param null $salt
      * @param null $member
-     * @return bool|string
+     * @return bool|String
+     * @throws PasswordEncryptor_EncryptionFailed
      */
     public function encrypt($password, $salt = null, $member = null)
     {
@@ -63,6 +66,8 @@ class PasswordEncryptor_BCrypt extends PasswordEncryptor
     /**
      * @param string $hash
      * @param string $password
+     * @param null $salt
+     * @param null $member
      * @return bool
      */
     public function check($hash, $password, $salt = null, $member = null)


### PR DESCRIPTION
This causes an issue with the Password Reset funcitonality of SilverStripe. There is an active PR to update the hashing of passwords that will help resolve the overall issue once it’s merged.