### PR TITLE
bugfix - make FoxyCart a stand alone class

### DIFF
--- a/code/model/FoxyCart.php
+++ b/code/model/FoxyCart.php
@@ -5,7 +5,8 @@
  *
  */
 
-class FoxyCart extends Object {
+class FoxyCart
+{
 
 	private static $keyPrefix = 'dYnm1c';
 


### PR DESCRIPTION
extending `Object` breaks in PHP 7.2