### PR TITLE
fix(#422): null-guard trim() calls in ProductPage::onBeforeWrite()

### DIFF
--- a/src/Page/ProductPage.php
+++ b/src/Page/ProductPage.php
@@ -437,9 +437,9 @@ class ProductPage extends \Page implements PermissionProvider
             $holders->add($currentParent);
         }
 
-        $this->Title = trim($this->Title);
-        $this->Code = trim($this->Code);
-        $this->ReceiptTitle = trim($this->ReceiptTitle);
+        $this->Title = trim((string) $this->Title);
+        $this->Code = trim((string) $this->Code);
+        $this->ReceiptTitle = trim((string) $this->ReceiptTitle);
     }
 
     public function onAfterWrite()

--- a/tests/ProductPageTest.php
+++ b/tests/ProductPageTest.php
@@ -115,14 +115,25 @@ class ProductPageTest extends FS_Test
     {
         $this->logInWithPermission('ADMIN');
 
-        $holder = $this->objFromFixture(ProductHolder::class, 'default');
-        $holder->write();
-
         $product = $this->objFromFixture(ProductPage::class, 'product1');
         $product->Code = null;
         $product->ReceiptTitle = null;
+
+        // trim(null) already returns '' without fataling — the actual bug is the
+        // E_DEPRECATED notice itself, which some consuming projects' error
+        // handlers escalate to a fatal. Assert no deprecation is raised, not just
+        // that the value comes out right.
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            $deprecations[] = $errstr;
+            return true;
+        }, E_DEPRECATED);
+
         $product->write();
 
+        restore_error_handler();
+
+        $this->assertSame([], $deprecations);
         $this->assertSame('', $product->Code);
         $this->assertSame('', $product->ReceiptTitle);
     }

--- a/tests/ProductPageTest.php
+++ b/tests/ProductPageTest.php
@@ -103,6 +103,30 @@ class ProductPageTest extends FS_Test
         $this->assertTrue($product->Title == 'Test with trailing space');
     }
 
+    /**
+     * A record with a null Code/ReceiptTitle (legacy data, or any write path that
+     * doesn't touch those columns) must not fatal on write — onBeforeWrite() trims
+     * all three DB fields unconditionally on every save, not just when they're being
+     * changed.
+     *
+     * @throws \SilverStripe\ORM\ValidationException
+     */
+    public function testProductWriteWithNullCodeAndReceiptTitle()
+    {
+        $this->logInWithPermission('ADMIN');
+
+        $holder = $this->objFromFixture(ProductHolder::class, 'default');
+        $holder->write();
+
+        $product = $this->objFromFixture(ProductPage::class, 'product1');
+        $product->Code = null;
+        $product->ReceiptTitle = null;
+        $product->write();
+
+        $this->assertSame('', $product->Code);
+        $this->assertSame('', $product->ReceiptTitle);
+    }
+
     public function testProductCategoryCreation()
     {
         $this->logInWithPermission('Product_CANCRUD');


### PR DESCRIPTION
## Summary
- `ProductPage::onBeforeWrite()` trims `Title`/`Code`/`ReceiptTitle` unconditionally on every write. A null column (legacy data, or any write path that doesn't touch those fields) hits `trim(null)` — a PHP 8.1+ deprecation, fatal under some projects' error handlers.
- Cast each to `(string)` before trimming: identical behavior for any existing string value, only changes the null case from a crash to an empty string.
- Added a regression test alongside the existing title-whitespace tests, covering a write with both `Code` and `ReceiptTitle` explicitly null.

Closes #422

## Blast radius
Branch `5` is exactly at tag `5.0.0` (0 commits ahead), so this is a clean patch on the current release line. Confirmed via `composer.lock` inspection that at least one consumer (`dynamic/sheboygan-youth-sailing-installer`) pins `foxystripe` in its lock file rather than floating `^5.0`, so a future `5.0.1` tag won't silently change behavior anywhere without an explicit `composer update`.

## Test plan
- [x] `php -l` clean on both changed files
- [x] New test mirrors the existing `testProductTitleLeadingWhiteSpace`/`testProductTitleTrailingWhiteSpace` pattern
- [ ] CI (`silverstripe/gha-ci`) run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm6Y5LuoNJLfT19TnejNZR